### PR TITLE
🔧 Exclude *.min.* files from Prettier, cspell, and ESLint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ pnpm-workspace.yaml
 
 # custom
 .turbo
+*.min.*
 /apps/mockup/public/styles.css
 /apps/web/.svelte-kit
 /apps/web/src/lib/$generated

--- a/cspell.json
+++ b/cspell.json
@@ -13,6 +13,7 @@
     "node_modules",
     "/project-words.txt",
     // custom
+    "*.min.*",
     "*.avif",
     "*.icns",
     "*.mp4",

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -70,6 +70,6 @@ export default [
   },
   eslintConfigPrettier,
   {
-    ignores: ['**/.svelte-kit/', '**/$generated/'],
+    ignores: ['**/*.min.*', '**/.svelte-kit/', '**/$generated/'],
   },
 ];


### PR DESCRIPTION
- 🚫 .prettierignore: Add *.min.*
- 🚫 cspell.json: Add *.min.* to ignored files
- 🚫 ESLint: Add **/*.min.* to ignore patterns