### PR TITLE
🔨 Fix dependencies and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Monorepo template for creating a web application.
 
 > [!Caution]
-> Currently, `svelte-hmr` and `markuplint` do not support Svelte 5.
+> Currently, `markuplint` do not support Svelte 5.
 > We have manually modified `pnpm-lock.yaml` to forcibly use Svelte 5, which may cause issues during package updates.
-> When updating dependencies, please refer to [#ca2313](https://github.com/usagizmo/webapp-template/commit/ca2313d8f2ace872cd39cc864da91f589e0b3ff3) for guidance on how to correctly adjust `pnpm-lock.yaml`.
+> When updating dependencies, please refer to [#f99d33](https://github.com/usagizmo/webapp-template/commit/f99d333c742ca3b27db15b07b96993a029ea4e31) for guidance on how to correctly adjust `pnpm-lock.yaml`.
 
 ## What's inside?
 

--- a/apps/mockup/package.json
+++ b/apps/mockup/package.json
@@ -42,7 +42,7 @@
     "@tailwindcss/cli": "4.0.0-alpha.15",
     "browser-sync": "^3.0.3",
     "image-size": "^1.1.1",
-    "tailwindcss": "4.0.0-alpha.29",
+    "tailwindcss": "4.0.0-alpha.21",
     "vitest": "^2.1.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,7 +54,7 @@
     "supabase": "^1.207.9",
     "svelte": "5.1.0",
     "svelte-check": "^4.0.5",
-    "tailwindcss": "4.0.0-alpha.29",
+    "tailwindcss": "4.0.0-alpha.21",
     "tslib": "^2.8.0",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3881,7 +3881,7 @@ snapshots:
       '@markuplint/html-parser': 4.6.9
       '@markuplint/ml-ast': 4.4.6
       '@markuplint/parser-utils': 4.7.0
-      svelte: 4.2.19
+      svelte: 5.1.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       tailwindcss:
-        specifier: 4.0.0-alpha.29
-        version: 4.0.0-alpha.29
+        specifier: 4.0.0-alpha.21
+        version: 4.0.0-alpha.21
       vitest:
         specifier: ^2.1.3
         version: 2.1.3(@types/node@22.7.9)(lightningcss@1.27.0)
@@ -88,7 +88,7 @@ importers:
         version: 8.0.1
       tailwind-variants:
         specifier: ^0.2.1
-        version: 0.2.1(tailwindcss@4.0.0-alpha.29)
+        version: 0.2.1(tailwindcss@4.0.0-alpha.21)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -118,8 +118,8 @@ importers:
         specifier: ^4.0.5
         version: 4.0.5(picomatch@4.0.2)(svelte@5.1.0)(typescript@5.6.3)
       tailwindcss:
-        specifier: 4.0.0-alpha.29
-        version: 4.0.0-alpha.29
+        specifier: 4.0.0-alpha.21
+        version: 4.0.0-alpha.21
       tslib:
         specifier: ^2.8.0
         version: 2.8.0
@@ -3022,8 +3022,8 @@ packages:
   tailwindcss@4.0.0-alpha.15:
     resolution: {integrity: sha512-hlL3dKkgKTNz6dXe4OWJMngI9DdcJncGXvhhjdPkMc/Pqc81NCYaV/8Z11DZ4Djy5RSFfLf41HI6+DGeKtvJ2g==}
 
-  tailwindcss@4.0.0-alpha.29:
-    resolution: {integrity: sha512-yYirQ1zh370k1J4SAbE+1uhE5x0+c8xCv2ffbokbUiqmLL8NEVoFMYkZw1hfj/kafiC2au9aOB2xHZ1dO1g10A==}
+  tailwindcss@4.0.0-alpha.21:
+    resolution: {integrity: sha512-Ps3oqLhvjPt/XSm4dx4ky4sYkCSMHfn7JWattsEQyFkbLYo77t4/FOnRuQzjATLCMQz10e/HbZYjosSD/pBfSg==}
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
@@ -6349,14 +6349,14 @@ snapshots:
 
   tailwind-merge@2.5.4: {}
 
-  tailwind-variants@0.2.1(tailwindcss@4.0.0-alpha.29):
+  tailwind-variants@0.2.1(tailwindcss@4.0.0-alpha.21):
     dependencies:
       tailwind-merge: 2.5.4
-      tailwindcss: 4.0.0-alpha.29
+      tailwindcss: 4.0.0-alpha.21
 
   tailwindcss@4.0.0-alpha.15: {}
 
-  tailwindcss@4.0.0-alpha.29: {}
+  tailwindcss@4.0.0-alpha.21: {}
 
   tar@7.4.3:
     dependencies:


### PR DESCRIPTION
This pull request includes several changes to downgrade the `tailwindcss` dependency from version `4.0.0-alpha.29` to `4.0.0-alpha.21` across multiple files and updates the README to correct a reference link.

Dependency updates:

* [`apps/mockup/package.json`](diffhunk://#diff-9740a106ba77af6b086864ce9ba593660534e826e15f00ea7752139a89073688L45-R45): Downgraded `tailwindcss` from `4.0.0-alpha.29` to `4.0.0-alpha.21`.
* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L57-R57): Downgraded `tailwindcss` from `4.0.0-alpha.29` to `4.0.0-alpha.21`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL69-R70): Updated multiple entries to downgrade `tailwindcss` from `4.0.0-alpha.29` to `4.0.0-alpha.21`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL69-R70) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL91-R91) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL121-R122) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3025-R3026) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6352-R6359)

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R8): Updated the reference link for guidance on adjusting `pnpm-lock.yaml` to point to the correct commit.