### PR TITLE
♻️ Use clsx with svelte 5.16

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,7 @@
     "@sveltejs/kit": "^2.12.1",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tailwindcss/vite": "4.0.0-beta.3",
-    "svelte": "5.1.0",
+    "svelte": "^5.16.0",
     "svelte-check": "^4.0.5",
     "tailwindcss": "4.0.0-beta.3",
     "tslib": "^2.8.0",

--- a/apps/web/src/lib/features/comment/Comment.svelte
+++ b/apps/web/src/lib/features/comment/Comment.svelte
@@ -95,8 +95,7 @@
 </script>
 
 <div
-  class="py-2.5 duration-200"
-  class:bg-slate-100={isDeleting}
+  class={['py-2.5 duration-200', { 'bg-slate-100': isDeleting }]}
   role="listitem"
   onmouseenter={() => (isActionVisible = card.me ? true : false)}
   onmouseleave={() => (isActionVisible = false)}

--- a/apps/web/src/routes/admin/AdminHeaderTabs.svelte
+++ b/apps/web/src/routes/admin/AdminHeaderTabs.svelte
@@ -33,10 +33,14 @@
         {/if}
         <a
           {href}
-          class="relative inline-flex items-center justify-center space-x-1 rounded-md px-5 py-2 text-sm text-zinc-500 duration-200"
-          class:font-bold={isActive}
-          class:pointer-events-none={isActive}
-          class:text-zinc-500={!isActive}
+          class={[
+            'relative inline-flex items-center justify-center space-x-1 rounded-md px-5 py-2 text-sm text-zinc-500 duration-200',
+            {
+              'font-bold': isActive,
+              'pointer-events-none': isActive,
+              'text-zinc-500': !isActive,
+            },
+          ]}
         >
           {name}
         </a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,10 @@ importers:
         version: 3.4.1
       prettier-plugin-svelte:
         specifier: ^3.2.7
-        version: 3.3.2(prettier@3.4.1)(svelte@5.2.2)
+        version: 3.3.2(prettier@3.4.1)(svelte@5.16.0)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.8
-        version: 0.6.9(prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.2.2))(prettier@3.4.1)
+        version: 0.6.9(prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.16.0))(prettier@3.4.1)
       turbo:
         specifier: ^2.2.3
         version: 2.3.3
@@ -95,22 +95,22 @@ importers:
         version: link:../../packages/eslint-config
       '@sveltejs/adapter-auto':
         specifier: ^3.3.0
-        version: 3.3.1(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))
+        version: 3.3.1(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))
       '@sveltejs/kit':
         specifier: ^2.12.1
-        version: 2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+        version: 2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
-        version: 4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+        version: 4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       '@tailwindcss/vite':
         specifier: 4.0.0-beta.3
-        version: 4.0.0-beta.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.1.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+        version: 4.0.0-beta.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.16.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       svelte:
-        specifier: 5.1.0
-        version: 5.1.0
+        specifier: ^5.16.0
+        version: 5.16.0
       svelte-check:
         specifier: ^4.0.5
-        version: 4.1.0(picomatch@4.0.2)(svelte@5.1.0)(typescript@5.7.2)
+        version: 4.1.0(picomatch@4.0.2)(svelte@5.16.0)(typescript@5.7.2)
       tailwindcss:
         specifier: 4.0.0-beta.3
         version: 4.0.0-beta.3
@@ -146,7 +146,7 @@ importers:
         version: 12.1.1(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-svelte:
         specifier: ^2.46.0
-        version: 2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.2.2)
+        version: 2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.16.0)
       eslint-plugin-unused-imports:
         specifier: ^4.1.4
         version: 4.1.4(@typescript-eslint/eslint-plugin@8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))
@@ -155,7 +155,7 @@ importers:
         version: 15.12.0
       svelte-eslint-parser:
         specifier: ^0.43.0
-        version: 0.43.0(svelte@5.2.2)
+        version: 0.43.0(svelte@5.16.0)
       typescript-eslint:
         specifier: ^8.11.0
         version: 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
@@ -1332,6 +1332,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   cmd-shim@7.0.0:
     resolution: {integrity: sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1726,6 +1730,9 @@ packages:
 
   esrap@1.2.2:
     resolution: {integrity: sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==}
+
+  esrap@1.3.2:
+    resolution: {integrity: sha512-C4PXusxYhFT98GjLSmb20k9PREuUdporer50dhzGuJu9IJXktbMddVCMLAERl5dAHyAi73GWWCE4FVHGP1794g==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -3001,8 +3008,8 @@ packages:
       typescript:
         optional: true
 
-  svelte@5.1.0:
-    resolution: {integrity: sha512-qD0pUvL3P26Vx+K1VodZROSu7MjDHFDunEVZ+2d3LUDWHyYI87AJFOIws0HufKWHDgXbPO4FCSugmysnX4LDwA==}
+  svelte@5.16.0:
+    resolution: {integrity: sha512-Ygqsiac6UogVED2ruKclU+pOeMThxWtp9LG+li7BXeDKC2paVIsRTMkNmcON4Zejerd1s5sZHWx6ZtU85xklVg==}
     engines: {node: '>=18'}
 
   svelte@5.2.2:
@@ -4090,14 +4097,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))':
     dependencies:
-      '@sveltejs/kit': 2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+      '@sveltejs/kit': 2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
+  '@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+      '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -4109,27 +4116,27 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.0
-      svelte: 5.1.0
+      svelte: 5.16.0
       tiny-glob: 0.2.9
       vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+      '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       debug: 4.3.7
-      svelte: 5.1.0
+      svelte: 5.16.0
       vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
+  '@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.1.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)))(svelte@5.16.0)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.14
-      svelte: 5.1.0
+      svelte: 5.16.0
       vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)
       vitefu: 1.0.4(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))
     transitivePeerDependencies:
@@ -4199,12 +4206,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.0.0-beta.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.0.0-beta.3
 
-  '@tailwindcss/vite@4.0.0-beta.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.1.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
+  '@tailwindcss/vite@4.0.0-beta.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.16.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.28.2))':
     dependencies:
       '@tailwindcss/node': 4.0.0-beta.3
       '@tailwindcss/oxide': 4.0.0-beta.3
       lightningcss: 1.28.2
-      svelte-preprocess: 6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.1.0)(typescript@5.7.2)
+      svelte-preprocess: 6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.16.0)(typescript@5.7.2)
       tailwindcss: 4.0.0-beta.3
       vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.28.2)
     transitivePeerDependencies:
@@ -4628,6 +4635,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   cmd-shim@7.0.0: {}
 
   color-convert@2.0.1:
@@ -5009,7 +5018,7 @@ snapshots:
     dependencies:
       eslint: 9.15.0(jiti@2.4.0)
 
-  eslint-plugin-svelte@2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.2.2):
+  eslint-plugin-svelte@2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.16.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.15.0(jiti@2.4.0))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -5022,9 +5031,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.43.0(svelte@5.2.2)
+      svelte-eslint-parser: 0.43.0(svelte@5.16.0)
     optionalDependencies:
-      svelte: 5.2.2
+      svelte: 5.16.0
     transitivePeerDependencies:
       - ts-node
 
@@ -5120,6 +5129,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.6
+
+  esrap@1.3.2:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -5919,16 +5932,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.2.2):
+  prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.16.0):
     dependencies:
       prettier: 3.4.1
-      svelte: 5.2.2
+      svelte: 5.16.0
 
-  prettier-plugin-tailwindcss@0.6.9(prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.2.2))(prettier@3.4.1):
+  prettier-plugin-tailwindcss@0.6.9(prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.16.0))(prettier@3.4.1):
     dependencies:
       prettier: 3.4.1
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.2(prettier@3.4.1)(svelte@5.2.2)
+      prettier-plugin-svelte: 3.3.2(prettier@3.4.1)(svelte@5.16.0)
 
   prettier@3.4.1: {}
 
@@ -6264,19 +6277,19 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-check@4.1.0(picomatch@4.0.2)(svelte@5.1.0)(typescript@5.7.2):
+  svelte-check@4.1.0(picomatch@4.0.2)(svelte@5.16.0)(typescript@5.7.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.1
       fdir: 6.4.2(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.1.0
+      svelte: 5.16.0
       typescript: 5.7.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.43.0(svelte@5.2.2):
+  svelte-eslint-parser@0.43.0(svelte@5.16.0):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -6284,17 +6297,17 @@ snapshots:
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
     optionalDependencies:
-      svelte: 5.2.2
+      svelte: 5.16.0
 
-  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.1.0)(typescript@5.7.2):
+  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.16.0)(typescript@5.7.2):
     dependencies:
-      svelte: 5.1.0
+      svelte: 5.16.0
     optionalDependencies:
       postcss: 8.4.49
       postcss-load-config: 3.1.4(postcss@8.4.49)
       typescript: 5.7.2
 
-  svelte@5.1.0:
+  svelte@5.16.0:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -6303,8 +6316,9 @@ snapshots:
       acorn-typescript: 1.4.13(acorn@8.14.0)
       aria-query: 5.3.2
       axobject-query: 4.1.0
+      clsx: 2.1.1
       esm-env: 1.2.1
-      esrap: 1.2.2
+      esrap: 1.3.2
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.14


### PR DESCRIPTION
Svelte 5.16 now supports the use of objects (`clsx`) for `class`.

ref. https://svelte.dev/docs/svelte/class