### PR TITLE
⬆️ Upgrade pnpm and configure workspace dependencies

### DIFF
--- a/apps/mockup/README.md
+++ b/apps/mockup/README.md
@@ -30,6 +30,9 @@ If present, test for any changes to the content.
 - Framework Preset: `Other`
 - Root Directory: `apps/mockup`
 - Build Command: `cd ../.. && npx turbo run build --filter=mockup`
+- Corepack Configuration: Add the following environment variable to enable pnpm@10:
+  - Key: `ENABLE_EXPERIMENTAL_COREPACK`
+  - Value: `1`
 
 ### With Basic Authentication
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,3 +25,6 @@ You can preview the production build with `pnpm preview`.
 - Framework Preset: `SvelteKit`
 - Root Directory: `apps/web`
 - Environment Variables: Set 2 environment variables in `.env`
+- Corepack Configuration: Add the following environment variable to enable pnpm@10:
+  - Key: `ENABLE_EXPERIMENTAL_COREPACK`
+  - Value: `1`

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "turbo": "^2.2.3"
   },
-  "packageManager": "pnpm@9.14.4",
+  "packageManager": "pnpm@10.7.1",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
+onlyBuiltDependencies:
+  - '@sveltejs/kit'

--- a/project-words.txt
+++ b/project-words.txt
@@ -15,6 +15,7 @@ postgrest
 snakecase
 sssz
 supabase
+sveltejs
 tailwindcss
 tseslint
 turborepo


### PR DESCRIPTION
Upgrade pnpm to version 10.7.1 and update engine requirements.
Configure workspace dependencies and add `sveltejs` to the project-words dictionary.