### PR TITLE
♻️ Refactor getter methods to  across all stores

### DIFF
--- a/apps/web/src/lib/composables/useCounter.svelte.ts
+++ b/apps/web/src/lib/composables/useCounter.svelte.ts
@@ -3,9 +3,7 @@ export const useCounter = () => new Counter();
 class Counter {
   #count = $state(0);
 
-  get count() {
-    return this.#count;
-  }
+  readonly count = $derived<number>(this.#count);
 
   increment() {
     this.#count += 1;

--- a/apps/web/src/lib/stores/CommentStore.svelte.ts
+++ b/apps/web/src/lib/stores/CommentStore.svelte.ts
@@ -18,9 +18,7 @@ export class CommentStore {
     this.#userStore = userStore;
   }
 
-  get comments(): CommentWithProfile[] {
-    return this.#comments;
-  }
+  readonly comments = $derived<CommentWithProfile[]>(this.#comments);
 
   /**
    * Set comments

--- a/apps/web/src/lib/stores/UserStore.svelte.ts
+++ b/apps/web/src/lib/stores/UserStore.svelte.ts
@@ -22,21 +22,10 @@ export class UserStore {
     this.#supabaseStore = supabaseStore;
   }
 
-  get user(): User | null {
-    return this.#user;
-  }
-
-  get profile(): UserProfile | null {
-    return this.#profile;
-  }
-
-  get loading() {
-    return this.#loading;
-  }
-
-  get isAuthenticated(): boolean {
-    return this.#user !== null;
-  }
+  readonly user = $derived<User | null>(this.#user);
+  readonly profile = $derived<UserProfile | null>(this.#profile);
+  readonly loading = $derived<{ profile: boolean }>(this.#loading);
+  readonly isAuthenticated = $derived<boolean>(this.#user !== null);
 
   /**
    * Update user information


### PR DESCRIPTION
## Summary
- Refactor getter methods to use `$derived` in stores and composables for better Svelte 5 Runes API compliance
- Update `useCounter`, `CommentStore`, and `UserStore` to use `$derived` instead of getter methods
- Improve reactivity and type safety with explicit typing for derived values

## Changes
- `useCounter.svelte.ts`: Convert `count` getter to `$derived`
- `CommentStore.svelte.ts`: Convert `comments` getter to `$derived`
- `UserStore.svelte.ts`: Convert `user`, `profile`, `loading`, and `isAuthenticated` getters to `$derived`

## Test plan
- [x] Verify all stores and composables work correctly with new `$derived` implementation
- [x] Check that reactivity is maintained across all components using these stores
- [x] Run `pnpm test` to ensure no regressions
- [x] Test user authentication flow
- [x] Test comment functionality
- [x] Test counter functionality