### PR TITLE
Refactor auth navigation to use SvelteKit's invalidate and goto

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { ModeWatcher } from 'mode-watcher';
   import { onMount } from 'svelte';
 
+  import { invalidate } from '$app/navigation';
   import { PUBLIC_GA4_MEASUREMENT_ID } from '$env/static/public';
   import Footer from '$lib/components/pages/layout/Footer.svelte';
   import GA4 from '$lib/components/pages/layout/GA4.svelte';
@@ -25,8 +26,7 @@
         event === 'SIGNED_OUT' ||
         newSession?.expires_at !== session?.expires_at
       ) {
-        // invalidate('supabase:auth');
-        window.location.reload();
+        invalidate('supabase:auth');
         return;
       }
 

--- a/apps/web/src/routes/dashboard/+page.svelte
+++ b/apps/web/src/routes/dashboard/+page.svelte
@@ -3,6 +3,7 @@
   import LogOutIcon from '@lucide/svelte/icons/log-out';
   import { toast } from 'svelte-sonner';
 
+  import { goto } from '$app/navigation';
   import ProfileForm from '$lib/components/pages/auth/ProfileForm.svelte';
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
@@ -19,8 +20,9 @@
     if (error) {
       toast.error(error.message);
       isLoading = false;
+    } else {
+      goto('/auth/login');
     }
-    // To reload the screen in +layout.svelte, isLoading is not set to false here
   }
 </script>
 


### PR DESCRIPTION
## Summary
- Replace `window.location.reload()` with `invalidate('supabase:auth')` for auth state changes
- Add proper navigation to login page after sign out using `goto('/auth/login')`
- Improve user experience by avoiding full page reloads

## Test Plan
- [ ] Sign in to the application
- [ ] Navigate to dashboard
- [ ] Sign out and verify smooth redirect to login page
- [ ] Sign in again and verify auth state updates properly
- [ ] Test session expiry behavior