### PR TITLE
Refactor ProfileForm to use superForm's resetForm option

### DIFF
--- a/apps/web/src/lib/components/pages/auth/ProfileForm.svelte
+++ b/apps/web/src/lib/components/pages/auth/ProfileForm.svelte
@@ -18,23 +18,21 @@
     {
       SPA: true,
       validators: zod(ProfileSchema),
+      resetForm: false,
+      onUpdate: async ({ form }) => {
+        if (!form.valid) return;
+        const { error } = await userStore.updateUserProfile({
+          bio: form.data.bio,
+        });
+        if (error) {
+          toast.error(error.message);
+        } else {
+          toast.success('Profile updated successfully');
+        }
+      },
     },
   );
-  const { form, enhance, validate } = profileFormData;
-
-  async function handleUpdateProfileBio(event: Event) {
-    const target = event.target as HTMLTextAreaElement;
-    const bioErrors = await validate('bio');
-    if (bioErrors) return;
-
-    if (target.value === userStore.profile?.bio) return;
-    const { error } = await userStore.updateUserProfile({ bio: target.value });
-    if (error) {
-      toast.error(error.message);
-    } else {
-      toast.success('Profile updated successfully');
-    }
-  }
+  const { form, enhance, submit } = profileFormData;
 </script>
 
 <form use:enhance class="grid gap-6">
@@ -47,7 +45,7 @@
           placeholder="Tell us about yourself (within 20 characters)"
           rows={3}
           bind:value={$form.bio}
-          onblur={handleUpdateProfileBio}
+          onblur={() => submit()}
         />
       {/snippet}
     </Form.Control>


### PR DESCRIPTION
## Summary
- Replace manual form handling with superForm's built-in features
- Add `resetForm: false` option to prevent form data from resetting after submission
- Implement `onUpdate` callback for handling profile updates
- Simplify Textarea blur event to use `submit()` instead of custom handler

## Changes
- Remove `handleUpdateProfileBio` function
- Configure superForm with `resetForm: false` and `onUpdate` callback
- Update Textarea to call `submit()` on blur event

## Test Plan
- [ ] Navigate to profile page
- [ ] Edit bio field and click outside (blur event)
- [ ] Verify bio is updated without form reset
- [ ] Verify success toast appears after update
- [ ] Test validation by entering invalid data
- [ ] Verify form maintains new values after submission