### PR TITLE
🔧 Clean up Node.js references after migration to Bun

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [22]
 
-    name: Build (Node ${{ matrix.node }} on ${{ matrix.os }})
+    name: Build (Bun on ${{ matrix.os }})
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -39,11 +38,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: 🛎 Checkout
         uses: actions/checkout@v4
-
-      - name: 🏗 Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
 
       - name: 📦 Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ graph TB
 
 ### Prerequisites
 
-- [Node.js v22+](https://nodejs.org/)
 - [Bun](https://bun.sh/)
 - [Docker](https://www.docker.com/) (for local database)
 

--- a/apps/pages/package.json
+++ b/apps/pages/package.json
@@ -18,7 +18,7 @@
     "format:js": "eslint --fix .",
     "format:prettier": "prettier . --write --ignore-path=../../.prettierignore",
     "format": "run-p format:*",
-    "add-size-to-img": "node ./commands/add-size-to-img.js",
+    "add-size-to-img": "bun ./commands/add-size-to-img.js",
     "clean-image": "./commands/clean-image.sh",
     "deploy": "./commands/deploy.sh"
   },


### PR DESCRIPTION
## Summary
- Remove Node.js setup from GitHub Actions workflow
- Remove Node.js from README prerequisites
- Update package.json script from `node` to `bun`

Clean up remaining Node.js references after migrating to Bun in v2.13.0.

## Test plan
- [x] Verify CI runs successfully
- [x] Verify `bun add-size-to-img` command works